### PR TITLE
Rename sort-imports rule and add sort-variable-declarator-properties rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,10 @@ npm install --save-dev eslint-plugin-ocd
 
 ## Rules
 
-* [sort-imports](documentation/rules/sort-imports.md) – Sort imports alphabetically.
+### Stylistic Issues
+
+* [sort-import-declarations](documentation/rules/sort-import-declarations.md) – Sort imports alphabetically.
+* [sort-variable-declarator-properties](documentation/rules/sort-variable-declarator-properties.md) – Sort variable declarator properties alphabetically.
 
 [bithound-img]: https://www.bithound.io/github/ciena-blueplanet/eslint-plugin-ocd/badges/score.svg "bitHound"
 [bithound-url]: https://www.bithound.io/github/ciena-blueplanet/eslint-plugin-ocd

--- a/documentation/rules/sort-import-declarations.md
+++ b/documentation/rules/sort-import-declarations.md
@@ -1,4 +1,4 @@
-# sort-imports
+# sort-import-declarations
 
 This rule ensures imports are always sorted alphabetically by source.
 
@@ -7,7 +7,7 @@ This rule ensures imports are always sorted alphabetically by source.
 ```json
 {
   "rules": {
-    "ocd/sort-imports": 2
+    "ocd/sort-import-declarations": 2
   }
 }
 ```

--- a/documentation/rules/sort-variable-declarator-properties.md
+++ b/documentation/rules/sort-variable-declarator-properties.md
@@ -1,0 +1,27 @@
+# sort-variable-declarator-properties
+
+This rule ensures variable declarator properties are always sorted alphabetically.
+
+**ESLint Configuration**
+
+```json
+{
+  "rules": {
+    "ocd/sort-variable-declarator-properties": 2
+  }
+}
+```
+
+**Valid**
+
+```js
+import Ember from 'ember'
+const {Component, Logger} = Ember
+```
+
+**Invalid**
+
+```js
+import Ember from 'ember'
+const {Logger, Component} = Ember
+```

--- a/index.js
+++ b/index.js
@@ -2,11 +2,13 @@ module.exports = {
   configs: {
     'ocd': {
       rules: {
-        'ocd/sort-imports': 2
+        'ocd/sort-import-declarations': 2,
+        'ocd/sort-variable-declarator-properties': 2
       }
     }
   },
   rules: {
-    'sort-imports': require('./rules/sort-imports')
+    'sort-import-declarations': require('./rules/sort-import-declarations'),
+    'sort-variable-declarator-properties': require('./rules/sort-variable-declarator-properties')
   }
 }

--- a/rules/sort-import-declarations.js
+++ b/rules/sort-import-declarations.js
@@ -1,10 +1,4 @@
 /**
- * @typedef {Object} SortCheckResult
- * @property {Array<ESLintNode>} expected - import declaration nodes in expected order
- * @property {Boolean} notSorted - whether or not imports are not already sorted
- */
-
-/**
  * Sort import declarations alphabetically by source
  * @param {Array<ESLintNode>} items - import declarations
  * @returns {Array<ESLintNode>} sorted import declarations

--- a/rules/sort-variable-declarator-properties.js
+++ b/rules/sort-variable-declarator-properties.js
@@ -1,0 +1,90 @@
+/**
+ * Sort properties alphabetically by source
+ * @param {Array<ESLintNode>} items - properties
+ * @returns {Array<ESLintNode>} sorted properties
+ */
+function deterministicSort (items) {
+  var remainingItems = Array.from(items)
+  var sortedItems = []
+
+  while (remainingItems.length !== 0) {
+    var nextItem = remainingItems[0]
+    var nextItemIndex = 0
+
+    remainingItems
+      .forEach(function (item, index) {
+        if (item.key.name < nextItem.key.name) {
+          nextItem = item
+          nextItemIndex = index
+        }
+      })
+
+    sortedItems.push(nextItem)
+    remainingItems.splice(nextItemIndex, 1)
+  }
+
+  return sortedItems
+}
+
+/**
+ * Sort properties alphabetically
+ * @param {ESLintContext} context - context
+ * @param {Array<ESLintNode>} properties - property nodes
+ */
+function sortProperties (context, properties) {
+  var expected = deterministicSort(properties)
+  var sourceTextArray = context.getSourceCode().getText().split('')
+
+  properties
+    .forEach(function (property, index) {
+      var expectedProperty = expected[index]
+
+      if (property === expectedProperty) {
+        return
+      }
+
+      var expectedPropertyText = sourceTextArray
+        .slice(
+          expectedProperty.range[0],
+          expectedProperty.range[1]
+        )
+        .join('')
+
+      context.report({
+        fix: function (fixer) {
+          return fixer.replaceText(property, expectedPropertyText)
+        },
+        message: 'Expected ' + expectedProperty.key.name + ' instead of ' + property.key.name,
+        node: property
+      })
+    })
+}
+
+module.exports = {
+  create: function (context) {
+    return {
+      /**
+       * Make sure variable declarator properties are sorted
+       * @param {ESLintNode} node - variable declaration node
+       */
+      VariableDeclarator: function (node) {
+        var properties = node.id.properties
+
+        if (!properties || properties.length === 0) {
+          return
+        }
+
+        sortProperties(context, properties)
+      }
+    }
+  },
+  meta: {
+    deprecated: false,
+    docs: {
+      category: 'Stylistic Issues',
+      description: 'Ensure variable declarators are alphabetically sorted',
+      recommended: true
+    },
+    fixable: 'code'
+  }
+}

--- a/tests/sort-import-declarations.js
+++ b/tests/sort-import-declarations.js
@@ -1,9 +1,9 @@
 var RuleTester = require('eslint').RuleTester
-var rule = require('../rules/sort-imports')
+var rule = require('../rules/sort-import-declarations')
 
 var ruleTester = new RuleTester()
 
-ruleTester.run('sort-imports', rule, {
+ruleTester.run('sort-import-declarations', rule, {
   invalid: [
     {
       code: 'import Baz from "baz"\n' +

--- a/tests/sort-variable-declarator-properties.js
+++ b/tests/sort-variable-declarator-properties.js
@@ -1,0 +1,213 @@
+var RuleTester = require('eslint').RuleTester
+var rule = require('../rules/sort-variable-declarator-properties')
+
+var ruleTester = new RuleTester()
+
+ruleTester.run('sort-variable-declarator-properties', rule, {
+  invalid: [
+    {
+      code: 'import Ember from "ember"\n' +
+            'const {Logger, Component} = Ember',
+      errors: [
+        {
+          column: 8,
+          line: 2,
+          message: 'Expected Component instead of Logger',
+          type: 'Property'
+        },
+        {
+          column: 16,
+          line: 2,
+          message: 'Expected Logger instead of Component',
+          type: 'Property'
+        }
+      ],
+      output: 'import Ember from "ember"\n' +
+              'const {Component, Logger} = Ember',
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import Ember from "ember"\n' +
+            'const {\n' +
+            '  Logger,\n' +
+            '  Component\n' +
+            '} = Ember',
+      errors: [
+        {
+          column: 3,
+          line: 3,
+          message: 'Expected Component instead of Logger',
+          type: 'Property'
+        },
+        {
+          column: 3,
+          line: 4,
+          message: 'Expected Logger instead of Component',
+          type: 'Property'
+        }
+      ],
+      output: 'import Ember from "ember"\n' +
+              'const {\n' +
+              '  Component,\n' +
+              '  Logger\n' +
+              '} = Ember',
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import Ember from "ember"\n' +
+            'const {A, Logger, Component} = Ember',
+      errors: [
+        {
+          column: 11,
+          line: 2,
+          message: 'Expected Component instead of Logger',
+          type: 'Property'
+        },
+        {
+          column: 19,
+          line: 2,
+          message: 'Expected Logger instead of Component',
+          type: 'Property'
+        }
+      ],
+      output: 'import Ember from "ember"\n' +
+              'const {A, Component, Logger} = Ember',
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import Ember from "ember"\n' +
+            'const {\n' +
+            '  A,\n' +
+            '  Logger,\n' +
+            '  Component\n' +
+            '} = Ember',
+      errors: [
+        {
+          column: 3,
+          line: 4,
+          message: 'Expected Component instead of Logger',
+          type: 'Property'
+        },
+        {
+          column: 3,
+          line: 5,
+          message: 'Expected Logger instead of Component',
+          type: 'Property'
+        }
+      ],
+      output: 'import Ember from "ember"\n' +
+              'const {\n' +
+              '  A,\n' +
+              '  Component,\n' +
+              '  Logger\n' +
+              '} = Ember',
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import Ember from "ember"\n' +
+            'const {Logger, Component, set} = Ember',
+      errors: [
+        {
+          column: 8,
+          line: 2,
+          message: 'Expected Component instead of Logger',
+          type: 'Property'
+        },
+        {
+          column: 16,
+          line: 2,
+          message: 'Expected Logger instead of Component',
+          type: 'Property'
+        }
+      ],
+      output: 'import Ember from "ember"\n' +
+              'const {Component, Logger, set} = Ember',
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import Ember from "ember"\n' +
+            'const {\n' +
+            '  Logger,\n' +
+            '  Component,\n' +
+            '  set\n' +
+            '} = Ember',
+      errors: [
+        {
+          column: 3,
+          line: 3,
+          message: 'Expected Component instead of Logger',
+          type: 'Property'
+        },
+        {
+          column: 3,
+          line: 4,
+          message: 'Expected Logger instead of Component',
+          type: 'Property'
+        }
+      ],
+      output: 'import Ember from "ember"\n' +
+              'const {\n' +
+              '  Component,\n' +
+              '  Logger,\n' +
+              '  set\n' +
+              '} = Ember',
+      parser: 'babel-eslint'
+    }
+  ],
+  valid: [
+    {
+      code: 'import Ember from "ember"\n' +
+            'const {Component} = Ember',
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import Ember from "ember"\n' +
+            'const {Component, Logger} = Ember',
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import Ember from "ember"\n' +
+            'const {A, Component, Logger} = Ember',
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import Ember from "ember"\n' +
+            'const {A, Component, Logger, set} = Ember',
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import Ember from "ember"\n' +
+            'const {\n' +
+            '  Component\n' +
+            '} = Ember',
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import Ember from "ember"\n' +
+            'const {\n' +
+            '  Component,\n' +
+            '  Logger\n' +
+            '} = Ember',
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import Ember from "ember"\n' +
+            'const {\n' +
+            '  A,\n' +
+            '  Component,\n' +
+            '  Logger\n' +
+            '} = Ember',
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import Ember from "ember"\n' +
+            'const {\n' +
+            '  A,\n' +
+            '  Component,\n' +
+            '  Logger,\n' +
+            '  set\n' +
+            '} = Ember',
+      parser: 'babel-eslint'
+    }
+  ]
+})


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Added** `sort-variable-declarator-properties` rule to make sure variable declarator properties are sorted alphabetically.
* **Renamed** `sort-imports` rule to `sort-import-declarations`.
