### PR TITLE
Add sort-import-declaration-specifiers rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ npm install --save-dev eslint-plugin-ocd
 
 ### Stylistic Issues
 
-* [sort-import-declarations](documentation/rules/sort-import-declarations.md) – Sort imports alphabetically.
+* [sort-import-declaration-specifiers](documentation/rules/sort-import-declaration-specifiers.md) – Sort import declaration specifiers alphabetically.
+* [sort-import-declarations](documentation/rules/sort-import-declarations.md) – Sort import declarations alphabetically.
 * [sort-variable-declarator-properties](documentation/rules/sort-variable-declarator-properties.md) – Sort variable declarator properties alphabetically.
 
 [bithound-img]: https://www.bithound.io/github/ciena-blueplanet/eslint-plugin-ocd/badges/score.svg "bitHound"

--- a/documentation/rules/sort-import-declaration-specifiers.md
+++ b/documentation/rules/sort-import-declaration-specifiers.md
@@ -1,0 +1,25 @@
+# sort-import-declaration-specifiers
+
+This rule ensures import declaration specifiers are always sorted alphabetically.
+
+**ESLint Configuration**
+
+```json
+{
+  "rules": {
+    "ocd/sort-import-declaration-specifiers": 2
+  }
+}
+```
+
+**Valid**
+
+```js
+import {describe, it} from 'mocha'
+```
+
+**Invalid**
+
+```js
+import {it, describe} from 'mocha'
+```

--- a/index.js
+++ b/index.js
@@ -2,12 +2,14 @@ module.exports = {
   configs: {
     'ocd': {
       rules: {
+        'ocd/sort-import-declaration-specifiers': 2,
         'ocd/sort-import-declarations': 2,
         'ocd/sort-variable-declarator-properties': 2
       }
     }
   },
   rules: {
+    'sort-import-declaration-specifiers': require('./rules/sort-import-declaration-specifiers'),
     'sort-import-declarations': require('./rules/sort-import-declarations'),
     'sort-variable-declarator-properties': require('./rules/sort-variable-declarator-properties')
   }

--- a/rules/sort-import-declaration-specifiers.js
+++ b/rules/sort-import-declaration-specifiers.js
@@ -1,0 +1,93 @@
+/**
+ * Sort import specifiers alphabetically by imported name
+ * @param {Array<ESLintNode>} items - import specifiers
+ * @returns {Array<ESLintNode>} sorted import specifiers
+ */
+function deterministicSort (items) {
+  var remainingItems = Array.from(items)
+  var sortedItems = []
+
+  while (remainingItems.length !== 0) {
+    var nextItem = remainingItems[0]
+    var nextItemIndex = 0
+
+    remainingItems
+      .forEach(function (item, index) {
+        if (item.imported.name < nextItem.imported.name) {
+          nextItem = item
+          nextItemIndex = index
+        }
+      })
+
+    sortedItems.push(nextItem)
+    remainingItems.splice(nextItemIndex, 1)
+  }
+
+  return sortedItems
+}
+
+/**
+ * Sort import specifiers alphabetically
+ * @param {ESLintContext} context - context
+ * @param {Array<ESLintNode>} ImportSpecifiers - import specifier nodes
+ */
+function sortImportSpecifiers (context, ImportSpecifiers) {
+  var expected = deterministicSort(ImportSpecifiers)
+  var sourceTextArray = context.getSourceCode().getText().split('')
+
+  ImportSpecifiers
+    .forEach(function (importSpecifier, index) {
+      var expectedImportSpecifier = expected[index]
+
+      if (importSpecifier === expectedImportSpecifier) {
+        return
+      }
+
+      var expectedPropertyText = sourceTextArray
+        .slice(
+          expectedImportSpecifier.range[0],
+          expectedImportSpecifier.range[1]
+        )
+        .join('')
+
+      context.report({
+        fix: function (fixer) {
+          return fixer.replaceText(importSpecifier, expectedPropertyText)
+        },
+        message: 'Expected ' + expectedImportSpecifier.imported.name + ' instead of ' + importSpecifier.imported.name,
+        node: importSpecifier
+      })
+    })
+}
+
+module.exports = {
+  create: function (context) {
+    return {
+      /**
+       * Make sure import declarator properties are sorted
+       * @param {ESLintNode} node - import declarator node
+       */
+      ImportDeclaration: function (node) {
+        var nonDefaultSpecifiers = node.specifiers
+          .filter(function (specifier) {
+            return specifier.type === 'ImportSpecifier'
+          })
+
+        if (!nonDefaultSpecifiers.length === 0) {
+          return
+        }
+
+        sortImportSpecifiers(context, nonDefaultSpecifiers)
+      }
+    }
+  },
+  meta: {
+    deprecated: false,
+    docs: {
+      category: 'Stylistic Issues',
+      description: 'Ensure import declarators are alphabetically sorted',
+      recommended: true
+    },
+    fixable: 'code'
+  }
+}

--- a/rules/sort-variable-declarator-properties.js
+++ b/rules/sort-variable-declarator-properties.js
@@ -65,7 +65,7 @@ module.exports = {
     return {
       /**
        * Make sure variable declarator properties are sorted
-       * @param {ESLintNode} node - variable declaration node
+       * @param {ESLintNode} node - variable declarator node
        */
       VariableDeclarator: function (node) {
         var properties = node.id.properties

--- a/tests/sort-import-declaration-specifiers.js
+++ b/tests/sort-import-declaration-specifiers.js
@@ -1,0 +1,95 @@
+var RuleTester = require('eslint').RuleTester
+var rule = require('../rules/sort-import-declaration-specifiers')
+
+var ruleTester = new RuleTester()
+
+ruleTester.run('sort-import-declaration-specifiers', rule, {
+  invalid: [
+    {
+      code: 'import {it, describe} from "mocha"',
+      errors: [
+        {
+          column: 9,
+          line: 1,
+          message: 'Expected describe instead of it',
+          type: 'ImportSpecifier'
+        },
+        {
+          column: 13,
+          line: 1,
+          message: 'Expected it instead of describe',
+          type: 'ImportSpecifier'
+        }
+      ],
+      output: 'import {describe, it} from "mocha"',
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import {describe, beforeEach, it} from "mocha"',
+      errors: [
+        {
+          column: 9,
+          line: 1,
+          message: 'Expected beforeEach instead of describe',
+          type: 'ImportSpecifier'
+        },
+        {
+          column: 19,
+          line: 1,
+          message: 'Expected describe instead of beforeEach',
+          type: 'ImportSpecifier'
+        }
+      ],
+      output: 'import {beforeEach, describe, it} from "mocha"',
+      parser: 'babel-eslint'
+    }
+  ],
+  valid: [
+    {
+      code: 'import {it} from "mocha"',
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import {describe, it} from "mocha"',
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import {beforeEach, describe, it} from "mocha"',
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import {afterEach, beforeEach, describe, it} from "mocha"',
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import {\n' +
+            '  it\n' +
+            '} from "mocha"',
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import {\n' +
+            '  describe,\n' +
+            '  it\n' +
+            '} from "mocha"',
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import {\n' +
+            '  beforeEach,\n' +
+            '  describe,\n' +
+            '  it\n' +
+            '} from "mocha"',
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'import {\n' +
+            '  afterEach,\n' +
+            '  beforeEach,\n' +
+            '  describe,\n' +
+            '  it\n' +
+            '} from "mocha"',
+      parser: 'babel-eslint'
+    }
+  ]
+})

--- a/tests/sort-variable-declarator-properties.js
+++ b/tests/sort-variable-declarator-properties.js
@@ -208,6 +208,16 @@ ruleTester.run('sort-variable-declarator-properties', rule, {
             '  set\n' +
             '} = Ember',
       parser: 'babel-eslint'
+    },
+    {
+      code: 'const a = [1, 2]\n' +
+            'const [b, c] = a',
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'const a = [1, 2]\n' +
+            'const [c, b] = a',
+      parser: 'babel-eslint'
     }
   ]
 })


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Added** `sort-import-declaration-specifiers` rule to sort import declaration specifiers alphabetically.
