### PR TITLE
Make sort-imports allow separating internal and external packages

### DIFF
--- a/documentation/rules/sort-import-declarations.md
+++ b/documentation/rules/sort-import-declarations.md
@@ -25,3 +25,34 @@ import {describe, it} from 'mocha'
 import {describe, it} from 'mocha'
 import chai from 'chai'
 ```
+
+## Separate External and Internal Imports
+
+If you prefer to separate external packages from internal packages you can configure this rule to ensure each section is sorted properly.
+
+```json
+{
+  "rules": {
+    "ocd/sort-import-declarations": [
+      2,
+      {
+        "localPrefixes": [
+          "../",
+          "./",
+          "dummy/"
+        ]
+      }
+    ]
+  }
+}
+```
+
+**Valid**
+
+```js
+import alpha from 'alpha'
+
+import bar from '../bar'
+import baz from './baz'
+import spam from 'dummy/spam'
+```

--- a/rules/sort-import-declaration-specifiers.js
+++ b/rules/sort-import-declaration-specifiers.js
@@ -73,7 +73,7 @@ module.exports = {
             return specifier.type === 'ImportSpecifier'
           })
 
-        if (!nonDefaultSpecifiers.length === 0) {
+        if (nonDefaultSpecifiers.length === 0) {
           return
         }
 

--- a/rules/sort-import-declarations.js
+++ b/rules/sort-import-declarations.js
@@ -78,7 +78,36 @@ module.exports = {
           return
         }
 
-        sortImportDeclarations(context, importDeclarations)
+        if (context.options.length === 0 ||
+          !context.options[0].localPrefixes ||
+          !context.options[0].localPrefixes.length === 0
+        ) {
+          sortImportDeclarations(context, importDeclarations)
+          return
+        }
+
+        var externalImportDeclarations = []
+        var localImportDeclarations = []
+        var localPrefixes = context.options[0].localPrefixes
+
+        importDeclarations
+          .forEach(function (importDeclaration) {
+            var local = false
+            var source = importDeclaration.source.value
+
+            localPrefixes
+              .forEach(function (prefix) {
+                if (source.indexOf(prefix) === 0) {
+                  local = true
+                }
+              })
+
+            var array = local ? localImportDeclarations : externalImportDeclarations
+            array.push(importDeclaration)
+          })
+
+        sortImportDeclarations(context, externalImportDeclarations)
+        sortImportDeclarations(context, localImportDeclarations)
       }
     }
   },
@@ -89,6 +118,19 @@ module.exports = {
       description: 'Ensure import declarations are alphabetically sorted by source',
       recommended: true
     },
-    fixable: 'code'
+    fixable: 'code',
+    schema: [
+      {
+        properties: {
+          localPrefixes: {
+            items: {
+              type: 'string'
+            },
+            type: 'array'
+          }
+        },
+        type: 'object'
+      }
+    ]
   }
 }

--- a/tests/sort-import-declaration-specifiers.js
+++ b/tests/sort-import-declaration-specifiers.js
@@ -90,6 +90,10 @@ ruleTester.run('sort-import-declaration-specifiers', rule, {
             '  it\n' +
             '} from "mocha"',
       parser: 'babel-eslint'
+    },
+    {
+      code: 'import Ember from "ember"',
+      parser: 'babel-eslint'
     }
   ]
 })

--- a/tests/sort-import-declarations.js
+++ b/tests/sort-import-declarations.js
@@ -209,6 +209,22 @@ ruleTester.run('sort-import-declarations', rule, {
             'import {afterEach, beforeEach, describe} from "mocha"\n' +
             'import sinon from "sinon"',
       parser: 'babel-eslint'
+    },
+    {
+      code: 'import foo from "foo"\n' +
+            'import bar from "../bar"\n' +
+            'import baz from "./baz"\n' +
+            'import spam from "dummy/spam"',
+      options: [
+        {
+          localPrefixes: ['../', './', 'dummy/']
+        }
+      ],
+      parser: 'babel-eslint'
+    },
+    {
+      code: 'export default {}',
+      parser: 'babel-eslint'
     }
   ]
 })


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Added** option to `sort-imports` rule to allow separating local and external packages, with each group being properly sorted.
