### PR TITLE
Update dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ sudo: required
 dist: trusty
 language: node_js
 node_js:
-  - '4.7'
-  - '5.12'
   - '6.9'
   - 'stable'
 branches:

--- a/package.json
+++ b/package.json
@@ -5,17 +5,19 @@
   },
   "description": "Obsessive compulsive ESLint rules for Javascript projects.",
   "devDependencies": {
-    "eslint": "^3.0.1",
+    "eslint": "^4.11.0",
     "istanbul": "^0.4.5",
-    "mocha": "^3.2.0"
+    "mocha": "^4.0.1"
   },
   "dependencies": {
-    "babel-eslint": "^7.1.1",
-    "eslint-config-standard": "^6.2.1",
-    "eslint-plugin-promise": "^3.4.0",
-    "eslint-plugin-standard": "^2.0.1",
-    "remark-cli": "^2.1.0",
-    "remark-lint": "^5.4.0"
+    "babel-eslint": "^8.0.2",
+    "eslint-config-standard": "^10.2.1",
+    "eslint-plugin-import": "^2.8.0",
+    "eslint-plugin-node": "^5.2.1",
+    "eslint-plugin-promise": "^3.6.0",
+    "eslint-plugin-standard": "^3.0.1",
+    "remark-cli": "^4.0.0",
+    "remark-lint": "^6.0.1"
   },
   "engines": {
     "node": ">= 4.0.0"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "remark-lint": "^6.0.1"
   },
   "engines": {
-    "node": ">= 4.0.0"
+    "node": ">= 6.0.0"
   },
   "keywords": [
     "eslint",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "remark-lint": "^6.0.1"
   },
   "engines": {
-    "node": ">= 6.0.0"
+    "node": ">= 6.9.0"
   },
   "keywords": [
     "eslint",

--- a/package.json
+++ b/package.json
@@ -5,13 +5,15 @@
   },
   "description": "Obsessive compulsive ESLint rules for Javascript projects.",
   "devDependencies": {
-    "babel-eslint": "^7.1.1",
     "eslint": "^3.0.1",
+    "istanbul": "^0.4.5",
+    "mocha": "^3.2.0"
+  },
+  "dependencies": {
+    "babel-eslint": "^7.1.1",
     "eslint-config-standard": "^6.2.1",
     "eslint-plugin-promise": "^3.4.0",
     "eslint-plugin-standard": "^2.0.1",
-    "istanbul": "^0.4.5",
-    "mocha": "^3.2.0",
     "remark-cli": "^2.1.0",
     "remark-lint": "^5.4.0"
   },


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [ ] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [X] #major# - incompatible API change

# CHANGELOG
* **Updated** into separate dependencies and devDependencies
* **Updated** to version 4 of `eslint`  
* **Updated** to version 4 of `mocha`
* **Updated** to version 8 of `babel-eslint`
* **Updated** to version 10 of `eslint-config-standard`
* **Added** now needed `eslint-plugin-import` dependency
* **Added** now needed `eslint-plugin-node` dependency
* **Updated** to version 3 of `eslint-plugin-standard`
* **Updated** to version 4 of `remark-cli`
* **Updated** to version 6 of `remark-lint`
* **Updated** version of node to `>= 6.9.0`
* **Removed** running of node versions 4 and 5 from travis CI