### PR TITLE
Update to pr-bumper version 2

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,9 @@
-**This project uses [semver](http://semver.org), please check the scope of this pr:**
+### This project uses [semver](semver.org), please check the scope of this pr:
 
+- [ ] #none# - documentation fixes and/or test additions
 - [ ] #patch# - backwards-compatible bug fix
 - [ ] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change
 
 # CHANGELOG
-
 Please add a description of your change here, it will be automatically prepended to the `CHANGELOG.md` file.

--- a/.pr-bumper.json
+++ b/.pr-bumper.json
@@ -1,0 +1,7 @@
+{
+  "features": {
+    "changelog": {
+      "enabled": true
+    }
+  }
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,8 @@ sudo: required
 dist: trusty
 language: node_js
 node_js:
-  - '6.9.1'
+  - '6.11.0'
   - 'stable'
-branches:
-  except:
-    - /^v[0-9\.]+/
 addons:
   apt:
     sources:
@@ -24,7 +21,7 @@ env:
     secure: aI/15mOf66vVy4iUV9Bw+nu1YJwunKxkH0CU3Uodn7c8GnuixKpdjGu0ljPk07uZXYBzDxRDUeEE2Gnov6rL1GmMQqW0nrKdU0IXms3ZY0WMz5NEVh3soVqLpAlqh/WfYvdW/kfiiIlIRlxBCVcWuZrOJSDQNU0VMrTHysi2ajeqkn7QaPgX9n38iZbPmAI8+4IzHsLF4mJhY6MfzBn7y29Yltuuib0aQLwZl6Lr8gbJZbgyIw1LAKB4n9RjMiXJ+aGzr6V0gxEtaU8WwTnDrFoH1hY/6+FeaRwvID2KXJ+PmmZUwoPochbR1a33Rb/baUUIdjB8aZPxhTyoEdB7r/NVsPJYXYSzRLmyIrs3ECsd0kMDYRdas34S9UOLWN9DNHaOAHZ2Gn5QbqzsP6YAX8fcYoGFR3Z8Q5XqCLA4bikSMpVecrRKFKT9+eoJwJpM7bO1PiqMsWFepT3qDoG4egj8A7iHJ/y0Zkk87/3iKYr2pmBLzEsMd+tfRKoyGr13Jg4SnDUdWomRWFDqeBzajHJ7XfVOOvOhM7JQ5/7WALrsTRfe/Q9WRLg7CWKPRUS4LcePMDXiZfoN0jhxLl4Rr/l6ZzO/gA09TmT1yL0VOeXcaZcDCY5HfFQPS59PjHhhuw8AuDjkqIR2I080122gBk+Wy3CLYb/ITKGiWw5vHFI=
 before_install:
   - npm config set spin false
-  - npm install -g coveralls pr-bumper@^1.0.0
+  - npm install -g coveralls pr-bumper@^2.0.0
   - $(npm root -g)/pr-bumper/.travis/maybe-check-scope.sh
 install:
   - $(npm root -g)/pr-bumper/.travis/maybe-install.sh
@@ -46,7 +43,7 @@ deploy:
     secure: br1VPEEXdNExe1/FmOHTOKLFMttgwRbUzcGWl4Stq1CpjYz93lkUL4F5z+AijG/nIZUptRmDVF97P1HCp8Ji5YlflO+ab4zjQBb/u8STU6A0nclUSULiPj2SQ/Ajp7avtJFgw4JBkMWIBcKHDkLRKD0Gg1A8Uza5jjp+6Rp2RaQVOqgDEHiONBb8dISxBn2SsZW/cYo6WRahqm51nQPbzLXn/p35X4GHHH+oipx3f4PChvt02jzqLH1mHR3QsHksuWDphueNu+XWGaM8xPV8cVQzBN9JmN1X2a24Ov4+sqbTagdKGGCivUEkDeZVV4B5Wf5Ss5L0IsWVSJIAVnG6EGeh/U/Vv7mHVt9z9cnOGEg4ffeokW8zCpp7vU/VDolYDnPZfm/TtHQjQ4VO04wyY7A62QJG/KlU3x0N/8vmI1IIv3llgdDK5JGtNG3QfaaahLouKdf4pLSRku5QpzN0uRh0JxeQG70PcIiUU4w9me3gdbfn2Fp+Chu0Fz1q1PwpdxeKhzKnKkCJOf7obTBx7JWGk9ZpKCCWONpsdRvd3krLyYDzYsj+bq7QjHCbYgVfpKB+M39garEMjvdA9X+fHZGXIOHA7SEQsFq9WvUDdDd6VvQrbKiYyjYVeGCdzpB6aFGS0I3iX58oChjJRl6WCG1t7KnLW7Qusm2aamn3Wtw=
   on:
     all_branches: true
-    node: '6.9.1'
+    node: '6.11.0'
     tags: true
 notifications:
 slack:

--- a/.travis/maybe-bump-version.sh
+++ b/.travis/maybe-bump-version.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [ "$TRAVIS_NODE_VERSION" != "6.9.1" ]
+if [ "$TRAVIS_NODE_VERSION" != "6.11.0" ]
 then
   echo "Skipping version bump for TRAVIS_NODE_VERSION ${TRAVIS_NODE_VERSION}"
   exit 0

--- a/.travis/maybe-publish-coverage.sh
+++ b/.travis/maybe-publish-coverage.sh
@@ -1,6 +1,14 @@
 #!/bin/bash
 
-if [ "$TRAVIS_NODE_VERSION" != "6.9.1" ]
+source $(npm root -g)/pr-bumper/.travis/is-bump-commit.sh
+
+if isBumpCommit
+then
+  echo "Skipping coverage publish for version bump commit"
+  exit 0
+fi
+
+if [ "$TRAVIS_NODE_VERSION" != "6.11.0" ]
 then
   echo "Skipping coverage publish for TRAVIS_NODE_VERSION ${TRAVIS_NODE_VERSION}"
   exit 0

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "remark-lint": "^6.0.1"
   },
   "engines": {
-    "node": ">= 6.9.1"
+    "node": ">= 6.11.0"
   },
   "keywords": [
     "eslint",


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [X] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG
* **Updated** to `pr-bumper` version 2
* **Updated** `PULL_REQUEST_TEMPLATE.md` with support for `pr-bumper #none#` option
* **Updated** the node engine version to `6.11.0`