### PR TITLE
Set engine node version to >= 6.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "remark-lint": "^6.0.1"
   },
   "engines": {
-    "node": ">= 6.11.0"
+    "node": ">= 6.0.0"
   },
   "keywords": [
     "eslint",


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [X] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG
* **Updated** engine node version to `>= 6.0.0`
