### PR TITLE
Remove reference to browser for an eslint plugin

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -52,9 +52,6 @@ We realize there is a lot of data requested here. We ask only that you do your b
 (answer all that are applicable)
 
 * [ ] I am using the latest released version (can check with `npm ls <package-name>`)
-* I am using these browsers:
-  * [ ] Latest Chrome
-  * [ ] Latest Firefox
 * [ ] My version of `Node` is:
 * [ ] My version of `npm` is:
 * [ ] My OS is:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,9 +13,6 @@ Put `Closes #XXXX` below to auto-close the issue that this PR addresses:
 
 * Closes #
 
-## Screenshots or recordings
-Please provide screenshots or recordings if this PR is modifying the visual UI or UX.
-
 ## Checklist
 * [ ] I have added tests that prove my fix is effective or that my feature works
 * [ ] I have evaluated if the _README.md_ documentation needs to be updated


### PR DESCRIPTION
# Overview

## Does this PR close an existing issue?
No. Filling out this PR template is enough effort for this, IMO and I don't plan on opening an issue to talk about this issue template fix. 

## Summary
This is an `eslint` plugin, there is no browser to be used, so asking for what browser version is being used in an issue template makes no sense. 

## Issue Number(s)
None.

# Semver

**This project uses [semver](http://semver.org), please check the scope of this PR:**

- [x] #none#
- [ ] #patch#
- [ ] #minor#
- [ ] #major#